### PR TITLE
Fix incorrect argument usage in argchecker

### DIFF
--- a/argchecker.py
+++ b/argchecker.py
@@ -17,7 +17,7 @@ class ArgChecker:
         assert not(args.is_test == 1 and args.future_bars <
                    2), "You want to test but the future bars are less than 2. That does not give us enough data to test the model properly. Please use a value larger than 2.\nExiting now..."
 
-        assert not(args.history_to_use != "all" and int(args.history_to_use_int) <
+        assert not(args.history_to_use != "all" and int(args.history_to_use) <
                    args.future_bars), "It is a good idea to use more history and less future bars. Please change these two values and try again.\nExiting now..."
 
         args.market_index = str(args.market_index).upper()


### PR DESCRIPTION
File "\eiten\argchecker.py", line 20, in check_arguments
    assert not(args.history_to_use != "all" and int(args.history_to_use_int) <
AttributeError: 'Namespace' object has no attribute 'history_to_use_int'